### PR TITLE
MonitorQuery: disable cache

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -39,7 +39,8 @@ export default function HomePage() {
         _gte: startDayjs.format(),
         _lt: nowDayjs.format()
       }
-    }
+    },
+    fetchPolicy: 'no-cache'
   })
 
   useEffect(() => {


### PR DESCRIPTION
稼働させているタブレットがおよそ60分おきにブラウザエラーを起こす問題の対策として、センサデータ取得のキャッシュを無効化する。

キャッシュ肥大によるメモリ不足によってクラッシュしていると予想（RAM 2GB）。

しばらく様子をみて、効果がありそうならマージする。