### PR TITLE
Switch to NextConfig output export from deprecated next export

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -3,7 +3,6 @@ const nextConfig = {
   reactStrictMode: true,
   swcMinify: true,
   output: "export",
-  trailingSlash: true,
 }
 
 module.exports = nextConfig

--- a/next.config.js
+++ b/next.config.js
@@ -2,6 +2,8 @@
 const nextConfig = {
   reactStrictMode: true,
   swcMinify: true,
+  output: "export",
+  trailingSlash: true,
 }
 
 module.exports = nextConfig

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "dev": "next dev",
-    "build": "next build && next export",
+    "build": "next build",
     "start": "next start",
     "lint": "next lint",
     "codegen": "graphql-codegen --require dotenv/config --config codegen.ts dotenv_config_path=.env.local"

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -92,7 +92,7 @@ export default function HomePage() {
 
   useEffect(() => {
     if (! hasToken()) {
-      router.push('/login/')
+      router.push('/login')
     }
   })
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -92,7 +92,7 @@ export default function HomePage() {
 
   useEffect(() => {
     if (! hasToken()) {
-      router.push('/login')
+      router.push('/login/')
     }
   })
 


### PR DESCRIPTION
非推奨化された`next export`コマンドを使うのをやめて、`next.config.js`で`output: export`を指定するように変更します。
