### PR TITLE
Enable trailing slash

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -3,6 +3,7 @@ const nextConfig = {
   reactStrictMode: true,
   swcMinify: true,
   output: "export",
+  trailingSlash: true,
 }
 
 module.exports = nextConfig

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -92,7 +92,7 @@ export default function HomePage() {
 
   useEffect(() => {
     if (! hasToken()) {
-      router.push('/login')
+      router.push('/login/')
     }
   })
 


### PR DESCRIPTION
trailing slashを有効化します。

ログインページが`/login.html`ではなく、`/login/index.html`に出力されるようにすることで、リロード時に404 Not Foundになる現象を回避して、静的ファイルホスティングサービスとの互換性を向上させる狙いがあります。
