### PR TITLE
docs: import agent workflow skills

### DIFF
--- a/.agents/skills/changelog-workflow/SKILL.md
+++ b/.agents/skills/changelog-workflow/SKILL.md
@@ -1,0 +1,133 @@
+---
+name: changelog-workflow
+description: >-
+  Create and update a canonical developer changelog. Use when adding
+  developer-facing release history, maintaining Keep a Changelog sections, or
+  preparing canonical version entries.
+---
+
+# Changelog Workflow
+
+## When to Use
+
+- Use this skill when updating the canonical developer changelog.
+- Use this skill when preparing canonical versioned release history before a
+  release.
+- Use this skill when preserving developer-facing prerelease, compatibility,
+  migration, CI/build/package, or implementation context.
+
+## Goals
+
+- Keep the confirmed canonical changelog, often `CHANGELOG.md`, as the
+  Keep a Changelog-style release history.
+- Record notable changes for maintainers in a human-readable, newest-first
+  format.
+- Preserve prerelease and internal context in the canonical changelog even when
+  it will not appear in user-facing release notes.
+- Preserve enough rationale and history for user-facing release notes to explain
+  why each user-visible change matters.
+- Keep user-facing release-note rewriting and release-readiness checks in the
+  dedicated release-note workflow.
+
+Reference:
+
+- Keep a Changelog 1.1.0: http://keepachangelog.com/en/1.1.0/
+
+## Workflow
+
+1. Update the canonical changelog first when a release-history change is
+   needed. If the file is not clearly `CHANGELOG.md`, locate or confirm the
+   canonical changelog before editing.
+2. Keep `Unreleased` at the top.
+3. Move `Unreleased` entries into a versioned section only when the maintainer
+   has selected the release version and UTC release date.
+   - Do not create placeholder version headings with `TBD`,
+     `<maintainer-selected date>`, or similar unfinished release metadata.
+     Keep draft material under `Unreleased` until the version and date are
+     known.
+4. Use Keep a Changelog categories when applicable: `Added`, `Changed`,
+   `Deprecated`, `Removed`, `Fixed`, and `Security`.
+   - Put supplemental release metadata that is not itself a change type, such as
+     compatibility notes and test environments, under `Notes` instead of making
+     separate top-level change-category headings.
+   - Put `Notes` after all change-category sections within each release entry.
+5. Keep versioned sections newest first, with headings such as
+   `## v1.2.3 - 2026-05-03 UTC`.
+6. Record developer-facing details that help future maintainers, including:
+   - Internal migrations or architecture changes.
+   - CI, build, packaging, or dependency context.
+   - Security-sensitive or supply-chain-sensitive context from `security-check`, such as
+     maintainer-approved exceptions, residual risk, or blockers that matter for future releases.
+   - Prerelease entries and why they matter.
+   - User-impact rationale or history for each user-visible change, such as
+     the problem it solves, why behavior changed, compatibility constraints, or
+     migration reason.
+   - A sourced user impact statement may be enough when it explains why users
+     should care. Generic bullets such as documentation updates, dependency
+     updates, crash fixes, or save-format changes still need source material
+     describing the user-facing benefit, risk, security impact, compatibility
+     impact, or migration reason.
+   - Compatibility notes, test environments, known limitations, yanked
+     releases, and migration constraints.
+   - Record compatibility, support, environment, and migration claims only when
+     they are maintainer-confirmed or clearly sourced. Otherwise list them as
+     missing inputs or draft source material needing confirmation, not as final
+     compatibility facts.
+   - When compatibility notes cover several platform, runtime, dependency, or
+     companion-product versions, preserve confidence differences instead of
+     flattening them into one generic compatibility statement. For example,
+     distinguish confirmed compatibility, "appears to work" best-effort
+     compatibility, lower-confidence limited checks, and known issues.
+   - Keep related compatibility claims grouped by relationship. Put companion
+     tools, required plugins, or paired dependencies under the product/version
+     they were tested with when that relationship matters, instead of listing
+     them as another peer product version.
+   - When historical entries are backfilled with metadata such as
+     compatibility information, state that the metadata was backfilled, when it
+     was backfilled, and whether it is reference information rather than an
+     original release claim.
+   - For yanked releases, explicitly say when historical metadata was not
+     backfilled because the release was yanked, if nearby releases did receive
+     backfilled metadata.
+7. When prerelease entries are later superseded, keep enough canonical history
+   to explain what changed and what reached the stable release. If the stable
+   release is still only planned, leave the stable roll-up material under
+   `Unreleased` instead of creating an unfinished stable heading.
+   - Attach withdrawn or superseded notes to the specific entry they affect,
+     rather than only adding a broad later correction. Name the later version
+     or release timing that withdrew or superseded the earlier wording.
+   - Avoid shorthand prerelease references such as `alpha.1` or `beta.2` when
+     the base version matters. Use the full prerelease version, such as
+     `v1.2.0-alpha.1`, in durable changelog text.
+   - Split long bullets into concise parent items with indented subitems when a
+     change contains several facts, reasons, affected versions, or follow-up
+     notes.
+   - Use `document-quality-check` when splitting or rewording changelog prose.
+     Preserve changelog-specific nuance such as compatibility confidence,
+     dependency relationships, and whether a statement is original, backfilled,
+     inferred, superseded, or withdrawn.
+8. If the user asks for user-facing release notes, verify or prepare only the
+   canonical source material here, then use the appropriate release-note
+   workflow for the user-facing rewrite and release-readiness checks.
+   - Update the canonical changelog only when the source material is missing,
+     stale, or needs maintainer-facing correction.
+   - Treat missing rationale or history for a user-visible change as missing
+     canonical source material; add or request it before user-facing rewriting.
+   - If the canonical changelog already contains enough source material, stop
+     there and hand off user-facing rewriting and readiness checks.
+   - Identify the release-note workflow by name when it exists; otherwise
+     discover the relevant release-note guidance before producing user-facing
+     notes.
+   - If confirmed version, UTC release date, target audience, publication
+     channel, or release-note workflow are missing, state those as input gaps
+     and stop after canonical source preparation.
+
+## Boundaries
+
+- This skill owns the canonical developer changelog; it does not own generated
+  or user-facing release-note files.
+- Do not publish, tag, create releases, upload artifacts, or edit release
+  metadata unless another workflow and explicit user request call for those
+  side effects.
+- Keep private workspace paths, temporary worktree names, command transcripts,
+  and authentication details out of public changelog text.

--- a/.agents/skills/changelog-workflow/agents/openai.yaml
+++ b/.agents/skills/changelog-workflow/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "Changelog Workflow"
+  short_description: "Update a canonical developer changelog."
+  default_prompt: >-
+    Update the canonical Keep a Changelog-style release history, preserving
+    developer-facing version, prerelease, compatibility, and maintainer context.

--- a/.agents/skills/code-quality-check/SKILL.md
+++ b/.agents/skills/code-quality-check/SKILL.md
@@ -1,0 +1,193 @@
+---
+name: code-quality-check
+description: >-
+  Quality-check source code, generated code, tests, scripts,
+  configuration-as-code, examples, dependencies, downloaded tools, CI actions,
+  and supply-chain-sensitive changes.
+---
+
+# Code Quality Check
+
+## When to Use
+
+Use this skill for any implementation change, regardless of language or framework, before
+committing or preparing a pull request.
+
+When the changed implementation is an Agent Skill, use `skill-quality-check` together with this
+skill for trigger design, structure, progressive disclosure, domain separation, and scenario
+validation expectations.
+
+## Goals
+
+- Make the changed code easy to read, review, debug, and safely modify later.
+- Prefer simple structure and clear names over explanatory comments.
+- Preserve important design decisions where future maintainers will need the context.
+- Avoid comment noise that repeats obvious code behavior.
+- Run the smallest meaningful executable checks first, then widen only when needed.
+- Keep verification notes concise and reusable for commit summaries, PR bodies, or handoff notes.
+- Use `security-check` when changes introduce or update security-sensitive behavior,
+  external dependencies, downloaded tools, CI actions, containers, vendored artifacts, or other
+  supply-chain-sensitive paths.
+
+## Workflow
+
+1. Re-read the changed files and nearby call sites, not just the patch.
+2. Identify code that is hard to scan, overly nested, duplicated, misleadingly named, or coupled to
+   hidden assumptions.
+3. Improve readability directly when a safe local refactor is practical.
+4. Add or update comments only when the design intent is not obvious from the code and cannot be
+   made obvious with a small refactor.
+5. Remove stale, redundant, or misleading comments.
+6. Use `document-quality-check` for documentation, comments, release notes, PR text, issue text,
+   and other explanatory prose that needs readability or wording changes.
+7. Re-run the project's language-specific quality checks after edits.
+8. Summarize which checks ran, which passed, and why any relevant check was skipped.
+
+When reviewing an abstract scenario or a proposed change without concrete files, produce a review
+plan instead of pretending to inspect code. State the assumptions, the readability changes you would
+try first, the comments you would keep or add, the text-audience classifications that must be made,
+and the checks you would run once real files exist.
+
+Separate missing input from skill ambiguity. If exact files, commands, release metadata, or
+provenance are unavailable, report them as assumptions, verification blockers, or target-change
+risks. Do not treat them as unclear points in this skill unless the workflow itself fails to say how
+to proceed.
+
+## Comment Policy
+
+Use comments to explain **why**, not **what**, unless the code is constrained by an external system
+or a non-obvious algorithm.
+
+Good reasons to leave a comment:
+
+- A trade-off was chosen and another reasonable approach was rejected.
+- The code works around a platform, API, data, timing, or compatibility constraint.
+- The code depends on ordering, lifetime, concurrency, precision, security, or performance behavior
+  that is easy to break later.
+- A compact algorithm or protocol step would be difficult to infer from names alone.
+- A fallback, validation rule, or migration path preserves behavior for older data.
+
+Prefer refactoring instead of commenting when:
+
+- A better variable, function, type, or module name would make the intent clear.
+- Extracting a small helper would remove nesting or repeated logic.
+- Reordering code, narrowing scope, or simplifying a condition would make the flow obvious.
+- The comment would merely restate assignments, branches, or function calls.
+
+When adding a comment:
+
+- Keep it close to the code it explains.
+- Keep it short and specific.
+- Name the constraint, trade-off, or invariant.
+- Make each comment an accurate explanation of the specific item it annotates. Do not use one
+  vague or generic comment to justify multiple unrelated lines, files, suppressions, exceptions, or
+  generated edits.
+- During bulk edits, review comments one by one after generation. Replace templated filler such as
+  "required for tests" or "framework compatibility" with the concrete reason for that exact site,
+  or remove the comment if no site-specific reason exists.
+- When introducing or tightening a comment policy, search the affected scope for existing comments
+  of that kind and apply the policy consistently. Do not update only the new examples while leaving
+  matching existing comments below the new standard.
+- Place comments where they do not break syntax-aware tooling or formatter grouping. If an adjacent
+  standalone comment would split an import block, list, mapping, or generated section in a way tools
+  rewrite or reject, use a same-line comment or another nearby location that preserves the group.
+- Update nearby tests or verification notes if the comment documents behavior that must stay true.
+
+### CI and Configuration Comments
+
+For configuration-as-code, CI workflows, build files, and tool configuration, intent comments are
+most useful near non-obvious fixed values: pinned tool versions, runtime images, lockfile paths,
+ordering constraints, suppressions, generated-file exclusions, timeout values, matrices, or external
+action references.
+
+When commenting on those values:
+
+- Explain the maintenance signal as well as the initial reason: when maintainers should revisit the
+  value and what compatibility, reproducibility, security, or operational constraint must stay true.
+- Keep broad repeated update policy in one maintained document or shared workflow guidance when
+  repeating it beside every value would drift.
+- Use local comments for site-specific constraints, exceptions, or links to central policy.
+- Avoid comments that merely restate the YAML key, tool option, version literal, or file path.
+
+## Developer-Facing Language
+
+Treat developer-facing text separately from user-facing text. This includes comments, log messages,
+exception messages, diagnostics, and internal assertions.
+
+Use English for developer-facing text regardless of the application's user-facing language.
+
+When the audience is unclear, classify whether the text is developer-facing, user-facing, or part of
+an external contract before changing it.
+
+## User-Facing Language
+
+Treat user-facing text separately from developer-facing text. This includes UI copy, CLI output,
+validation messages, accessibility text, and external API text shown to users or consumed by
+integrations.
+
+Follow the application's product copy, localization, accessibility, CLI output, and external API
+contract rules for user-facing text.
+
+Do not change user-facing text to English only to satisfy the developer-facing language policy. If a
+message can be both user-facing and developer-facing, classify its audience and contract first, then
+update tests, snapshots, docs, or changelog entries that intentionally cover that surface.
+
+## Design Decision Checklist
+
+Before finishing, check whether the change includes any design decision that future maintainers
+would not recover from the code alone:
+
+- Why this boundary, abstraction, data shape, or lifecycle was chosen.
+- Why a simpler-looking alternative is unsafe or intentionally avoided.
+- Why behavior differs across platforms, versions, modes, providers, or file formats.
+- Why an error is swallowed, retried, delayed, cached, normalized, or surfaced.
+- Why a broad dependency, global state, mutable state, or escape hatch is acceptable here.
+
+If the decision still matters after the code is cleaned up, record it with a concise comment near
+the relevant code. If the decision affects public behavior, configuration, operations, or release
+notes, also update the appropriate docs or changelog.
+
+## Verification Discipline
+
+- Start with the narrowest check that exercises the changed behavior, then run the broader
+  language-, framework-, or tool-specific checks expected by the project.
+- If a check fails, fix the narrow cause and rerun that same check before widening scope.
+- Do not skip executable checks only because dependencies or tools are not installed yet; install or
+  provision them using the project's documented workflow when that is safe and reproducible.
+- If verification is still impossible after setup, state the concrete blocker and the command that
+  could not run.
+- Keep verification consistent across local fixes, commits, and review or handoff preparation.
+- Record skipped checks with a concrete reason, not a generic "not run" note.
+
+## Supply-Chain Baseline
+
+Use `security-check` as the canonical security and supply-chain reference when a change
+introduces or updates external executable artifacts, dependency provenance, package-runner
+invocations, downloaded CLI tools, CI actions, containers, vendored files, generated code from
+external tools, copied files, or lockfile entries.
+
+At minimum:
+
+- Treat those paths as supply-chain-sensitive.
+- Require the repository's cooldown, pinning, provenance, and runtime-behavior checks before
+  adoption.
+- Report a blocker or documented maintainer exception when release age, provenance, runtime
+  behavior, or cooldown compliance cannot be verified.
+- For copied, generated, vendored, or downloaded files, record the source, version or commit, and
+  validation method when relevant.
+
+## Output Checklist
+
+- Readability issues were either fixed or deliberately left with a reason.
+- Important design intent is captured near the code, docs, or PR notes.
+- Comments explain non-obvious intent and do not repeat obvious code behavior.
+- Stale or misleading comments were removed.
+- Language-specific formatting, linting, typing, and tests were run or any skipped check has a
+  concrete reason.
+- Missing files, commands, metadata, or provenance were reported as assumptions, target-change
+  risks, or verification blockers rather than as findings invented from unavailable evidence.
+- Agent Skill changes were checked with `skill-quality-check` when applicable.
+- Security-sensitive behavior and supply-chain-sensitive artifacts were checked with
+  `security-check` when applicable.
+- If no concrete code was available, the output clearly says that this was a review plan and lists
+  the assumptions instead of presenting file-specific findings.

--- a/.agents/skills/code-quality-check/agents/openai.yaml
+++ b/.agents/skills/code-quality-check/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "Code Quality Check"
+  short_description: "Review code quality, maintainability, verification, and supply-chain-sensitive changes."
+  default_prompt: >-
+    Review this change for readability, maintainability, design intent,
+    verification discipline, and supply-chain-sensitive updates.

--- a/.agents/skills/commit-message-quality-check/SKILL.md
+++ b/.agents/skills/commit-message-quality-check/SKILL.md
@@ -1,0 +1,176 @@
+---
+name: commit-message-quality-check
+description: >-
+  Quality-check repository commit messages. Use when creating or updating commit
+  messages.
+---
+
+# Commit Message Quality Check
+
+## When to Use
+
+- Use this skill when creating, updating, reviewing, or validating a commit
+  message for this repository.
+
+## Goals
+
+- Check commit messages against Conventional Commits 1.0.0.
+- Check repository attribution policy, including AI agent co-author trailers.
+- Recommend message changes that fit the actual staged or committed change.
+- Keep commit guidance focused on message quality, not on reviewing the
+  underlying code or documentation diff.
+
+Reference:
+- Conventional Commits 1.0.0: https://www.conventionalcommits.org/en/v1.0.0/
+- GitHub co-authored commits:
+  https://docs.github.com/articles/creating-a-commit-with-multiple-authors
+
+## Workflow
+
+1. Read the proposed commit message and, when available, the staged diff or
+   commit diff it describes.
+2. Verify the first-line format, blank-line structure, body placement, and
+   footer placement.
+3. Check that the type, optional scope, breaking-change marker, and short
+   description match the dominant intent of the change.
+4. Check that any body explains useful context, motivation, or impact instead
+   of repeating the summary.
+5. Check required footer or trailer metadata, including `BREAKING CHANGE` and
+   AI agent `Co-authored-by:` trailers when applicable.
+6. Recommend the smallest correction that makes the message valid and accurate.
+7. If the diff contains multiple unrelated logical changes, recommend splitting
+   the commit when practical.
+
+## Format
+
+Verify that the first line uses:
+
+```text
+<type>[optional scope][optional !]: <description>
+```
+
+Verify the blank-line structure:
+
+- An optional body starts after one blank line.
+- Optional footer lines start after one blank line from the body.
+
+```text
+<type>[optional scope][optional !]: <description>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+## Components
+
+- `type`: required noun that communicates the kind of change.
+- `scope`: optional noun in parentheses that names the affected area, such as
+  `interop`, `build`, `docs`, or `input`.
+- `!`: optional marker immediately before `:` for a breaking change.
+- `description`: required short summary after `: `. Use imperative mood,
+  lowercase after the type unless a proper noun is needed, and no trailing
+  period.
+- `body`: optional free-form explanation of what changed and why. Start it one
+  blank line after the description.
+- `footer`: optional trailer-style metadata. Use tokens such as `Refs`,
+  `Reviewed-by`, `Co-authored-by`, or `BREAKING CHANGE`.
+
+## Breaking Changes
+
+Mark breaking changes with either:
+
+```text
+feat(api)!: remove legacy save endpoint
+```
+
+or:
+
+```text
+feat(api): remove legacy save endpoint
+
+BREAKING CHANGE: legacy save endpoint is no longer available.
+```
+
+`BREAKING CHANGE` must be uppercase when used as a footer.
+`BREAKING-CHANGE` is equivalent when used as a footer token.
+
+## AI Agent Co-Author Trailers
+
+When an AI agent materially created or changed content in the commit, check for
+an appropriate `Co-authored-by:` trailer unless repository or user instructions
+explicitly say not to add one. Do not add AI co-author attribution for passive
+lookup, review-only advice, formatting a user-written message, or incidental
+autocomplete unless the project policy requires it.
+
+Use this selection order:
+
+1. Prefer an explicit repository, organization, tool, or user-provided
+   attribution string.
+2. If the active agent/tool has a documented or configured default, use that
+   exact value.
+3. If no exact value is available, use a stable, privacy-preserving service
+   identity for the agent type.
+4. If the agent identity is unknown, use a generic local policy value only when
+   the repository defines one; otherwise omit the trailer and note the missing
+   attribution source.
+
+Known default examples:
+
+- Codex: `Co-authored-by: Codex <noreply@openai.com>`
+- Claude Code: `Co-authored-by: Claude <noreply@anthropic.com>`
+- GitHub Copilot: `Co-authored-by: Copilot <copilot@github.com>`
+
+If multiple AI agents materially contributed, add one `Co-authored-by:` trailer
+per agent. Put each trailer on its own line in the footer block, with no blank
+lines between consecutive trailer lines. Keep `BREAKING CHANGE` before ordinary
+metadata when it explains the change, and keep co-author trailers at the end
+unless another project rule says otherwise.
+
+## Type Selection
+
+Check that the type matches the dominant intent:
+
+- `feat`: add a user-visible feature or capability. SemVer: minor.
+- `fix`: correct a bug. SemVer: patch.
+- `perf`: improve runtime performance without changing behavior.
+- `refactor`: change code structure without adding features or fixing bugs.
+- `docs`: change documentation, comments intended as documentation, or repository guidance.
+- `test`: add, update, or remove tests.
+- `build`: change build scripts, project files, packaging, dependencies, or
+  generated build configuration.
+- `ci`: change continuous integration workflows or automation.
+- `style`: formatting-only change with no behavior impact.
+- `chore`: maintenance that does not fit the other types and does not affect
+  source, tests, build, docs, or CI in a more specific way.
+- `revert`: revert previous commits; include references in the body or footers when useful.
+
+Prefer the most specific type.
+If one logical change needs multiple types, recommend splitting it into multiple
+commits when practical.
+
+## Examples
+
+```text
+docs: add agent workflow skills
+```
+
+```text
+refactor(interop): remove redundant role checks
+```
+
+```text
+fix(input): ignore hotkeys while local player is busy
+```
+
+```text
+feat!: require current game interop adapters
+
+BREAKING CHANGE: legacy versioned adapters are no longer loaded.
+```
+
+```text
+docs: document agent attribution policy
+
+Co-authored-by: Codex <noreply@openai.com>
+```

--- a/.agents/skills/commit-message-quality-check/SKILL.md
+++ b/.agents/skills/commit-message-quality-check/SKILL.md
@@ -160,11 +160,11 @@ refactor(interop): remove redundant role checks
 ```
 
 ```text
-fix(input): ignore hotkeys while local player is busy
+fix(input): ignore shortcuts while input is disabled
 ```
 
 ```text
-feat!: require current game interop adapters
+feat!: require current API adapters
 
 BREAKING CHANGE: legacy versioned adapters are no longer loaded.
 ```

--- a/.agents/skills/commit-message-quality-check/agents/openai.yaml
+++ b/.agents/skills/commit-message-quality-check/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Commit Message Quality Check"
+  short_description: "Quality-check repository commit messages."
+  default_prompt: "Quality-check this commit message against the repository's Conventional Commits guidance."

--- a/.agents/skills/document-quality-check/SKILL.md
+++ b/.agents/skills/document-quality-check/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: document-quality-check
+description: >-
+  Quality-check documentation, comments, release notes, issue text, pull request
+  text, and Agent Skill prose for readability, structure, audience fit, and
+  preserved nuance.
+---
+
+# Document Quality Check
+
+## When to Use
+
+- Use this skill when creating, updating, or reviewing explanatory prose.
+- Use this skill for documentation, comments, release notes, issue text, pull request text, Agent
+  Skill prose, changelog entries, and handoff notes.
+- Use this skill together with domain-specific skills when those skills own the document type, such
+  as changelogs, release notes, issues, pull requests, or Agent Skills.
+
+## Goals
+
+- Make prose easy to scan without flattening meaning.
+- Preserve nuance that affects reader decisions, implementation safety, or release interpretation.
+- Match structure to content: sentences for simple ideas, lists for enumerations, and nested bullets
+  for grouped details.
+- Keep wording aligned with the target audience and the local document style.
+
+## Workflow
+
+1. Classify the text audience before rewriting:
+   - Developer-facing.
+   - User-facing.
+   - Maintainer-facing.
+   - External-contract text.
+2. Identify overloaded prose:
+   - Sentences carrying multiple ideas, conditions, time references, confidence levels, or
+     relationships.
+   - Paragraphs that mix context, decision, evidence, and consequence.
+   - List items that contain several facts, exceptions, examples, or follow-up notes.
+3. Prefer lists when presenting enumerations.
+   - Use inline prose only when the enumeration is short enough to read naturally or when the local
+     document style clearly favors inline wording.
+4. Split or restructure dense text when it becomes hard to scan.
+   - Use separate paragraphs, parent bullets with indented child bullets, tables, or another local
+     document pattern that makes each idea easy to review.
+   - When a sentence continues the same paragraph or comment block, prefer starting it on a new
+     physical line if the local format allows that without changing the rendered structure.
+   - Treat sentence-per-line wrapping as a reviewability aid, not as a paragraph break. Do not
+     apply it when it would make short prose, Markdown links, lists, tables, or formatter-controlled
+     code comments harder to read.
+   - Do not change wording strength, modality, tense, or voice only to make sentence wrapping work.
+     Keep wording unchanged unless an independent readability issue justifies rewriting it.
+5. Preserve the nuance that made the original wording important:
+   - Certainty or confidence level.
+   - Scope and applicability.
+   - Timing and sequence.
+   - Exception or limitation status.
+   - Dependency or compatibility relationships.
+   - Whether a statement is original, backfilled, inferred, superseded, withdrawn, or still
+     unconfirmed.
+6. Use as many short sentences or nested bullets as needed.
+   - Do not force a fixed sentence count when the content needs a different shape.
+7. Re-read the result as a whole.
+   - Confirm it still answers the same question as the original wording.
+   - Confirm each list or paragraph has one clear job.
+   - Confirm the structure did not imply a stronger, weaker, broader, or narrower claim than the
+     source material supports.
+
+## Output Checklist
+
+- Audience and document type were considered before rewriting.
+- Enumerations are lists unless inline prose is clearer for the local context.
+- Dense paragraphs or list items were split or intentionally left intact.
+- Important certainty, scope, timing, relationship, and status nuances were preserved.
+- The final text is easier to scan and still communicates the same claim.

--- a/.agents/skills/document-quality-check/agents/openai.yaml
+++ b/.agents/skills/document-quality-check/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Document Quality Check"
+  short_description: "Quality-check explanatory prose."
+  default_prompt: "Quality-check this prose for readability, structure, audience fit, and preserved nuance."

--- a/.agents/skills/git-worktree-workflow/SKILL.md
+++ b/.agents/skills/git-worktree-workflow/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: git-worktree-workflow
+description: Use Git worktrees for repository implementation tasks unless explicitly told not to.
+---
+
+# Git Worktree Workflow
+
+## When to Use
+
+- Use this skill for repository implementation work unless the user explicitly
+  instructs you not to use Git worktrees.
+- Implementation work includes code, tests, build files, documentation,
+  repository guidance, and pull-request preparation.
+
+## Workflow
+
+1. Check the current repository state.
+2. Fetch the latest base branch.
+3. Create a branch and worktree under `.agents/worktrees/`.
+4. Before editing, split the implementation plan into practical phases.
+5. For each phase, implement only that phase, then run its quality check inside the worktree.
+6. Commit the completed phase immediately using `commit-message-quality-check`.
+7. Repeat steps 5 and 6 until every planned phase is complete.
+8. Before pushing, run the final quality check.
+9. Push the branch.
+10. Create or update the pull request using `pull-request-quality-check`.
+
+## Worktree Setup
+
+Create implementation worktrees under:
+
+```text
+.agents/worktrees/
+```
+
+Use a short, descriptive branch and directory name, such as:
+
+```text
+.agents/worktrees/fix-state-load
+```
+
+Start from the latest base branch unless the user names a different base.
+The usual base is `main`:
+
+```powershell
+git fetch origin main
+git worktree add -b <branch-name> .agents/worktrees/<branch-name> origin/main
+```
+
+If network access or Git metadata writes require approval, request it and
+continue after approval.
+
+## Safety Rules
+
+- Treat uncommitted or untracked files in the original worktree as user work.
+- After creating the task worktree, make implementation changes there.
+- Do not remove another worktree unless the user explicitly asks.
+- If the branch or worktree path already exists, inspect it before reuse or
+  choose a new descriptive name.
+- Once a branch has been pushed or attached to a pull request, do not amend, rebase, squash,
+  force-push, or otherwise rewrite its history unless the user explicitly asks for history
+  rewriting.
+
+## Quality Check
+
+A quality check means formatting and verification appropriate to the change
+risk and repository conventions. Prefer documented project commands such as
+builds, tests, linters, formatters, or structural validators that cover the
+files changed.
+
+If verification is skipped, state why in the pull request body.
+
+The final quality check also includes reviewing:
+
+- The complete diff.
+- Recent commits.
+- Accidental scope creep.
+- Missing verification.
+- Commit-message quality.
+
+## Pull Request Notes
+
+- Keep pull request titles and bodies consistent with `pull-request-quality-check`.
+- For later corrections on an already-pushed pull request branch, add follow-up commits on top of
+  the branch so review history remains visible.
+- Remove temporary PR body files from the worktree after creating or editing the pull request.

--- a/.agents/skills/git-worktree-workflow/agents/openai.yaml
+++ b/.agents/skills/git-worktree-workflow/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "Git Worktree Workflow"
+  short_description: "Use Git worktrees for repository implementation tasks."
+  default_prompt: >-
+    Set up and use a Git worktree for this repository task, then follow the
+    repository's implementation and verification workflow.

--- a/.agents/skills/github-actions-quality-check/SKILL.md
+++ b/.agents/skills/github-actions-quality-check/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: github-actions-quality-check
+description: >-
+  Quality-check GitHub Actions workflows, composite actions, action pinning,
+  runner labels, permissions, triggers, concurrency, secrets, and CI linting
+  changes. Use when creating, editing, reviewing, or documenting GitHub Actions
+  automation.
+---
+
+# GitHub Actions Quality Check
+
+## When to Use
+
+- Use this skill when work touches `.github/workflows/`, `.github/actions/`,
+  action pinning, runner labels, workflow permissions, triggers, concurrency,
+  repository variables, repository secrets, or CI linting policy.
+- Use it with `security-check` for third-party actions, downloaded tools,
+  secrets, tokens, permissions, publishing, containers, or other supply-chain
+  sensitive changes.
+- Use `document-quality-check` when updating contributor-facing workflow
+  guidance or pull request notes.
+
+## Goals
+
+- Keep workflows readable, deterministic, least-privilege, and reviewable.
+- Catch workflow syntax, expression, runner-label, and composite-action metadata
+  mistakes before CI runs.
+- Keep third-party actions and reusable workflows pinned to full commit SHAs
+  with accurate version comments.
+- Prefer checks that do not add unnecessary runtime dependencies.
+- Record verification clearly, including any local/CI difference.
+
+## Workflow
+
+1. Inspect the changed workflow or action files and the repository guidance that
+   documents them.
+2. Check triggers, branch filters, merge queue behavior, and `workflow_dispatch`
+   coverage against the intended repository responsibility.
+3. Check `permissions` at workflow and job scope. Prefer `contents: read` unless
+   a job needs broader access, and document any write permission.
+4. Check concurrency groups and cancellation rules for PRs, pushes, releases,
+   merge queues, and publishing jobs.
+5. Check runner labels and local composite actions. Add or update
+   `.github/actionlint.yaml` only for deliberate labels or variables that
+   actionlint cannot infer.
+6. Run actionlint for workflow and action metadata validation. Match the
+   repository's documented command; when optional integrations would add
+   dependencies, disable them explicitly and note the reduced scope. Revisit
+   pyflakes disablement when Python scripts exist in the repository.
+7. Run ShellCheck for standalone shell scripts discovered in the changed
+   automation scope, and keep actionlint's ShellCheck integration enabled when
+   the repository installs ShellCheck.
+8. Run pinact in check mode for action and reusable-workflow pins. Use
+   `GITHUB_TOKEN` when available so API calls use authenticated rate limits.
+9. For new or updated external actions, downloaded tools, or containers, apply
+   `security-check`: verify release age, provenance, pinning, permissions, and
+   runtime behavior before adopting the artifact.
+10. Re-read comments near non-obvious versions, runner choices, cache paths,
+   suppressions, and install commands. Keep comments specific and actionable.
+11. Summarize verification by category: actionlint, ShellCheck, pinact, other
+    automated checks, AI-assisted inspection, and any skipped checks with
+    concrete blockers.
+
+## Command Examples
+
+Use these examples only when they match the repository's documented tooling.
+Discover shell files from the current repository instead of copying a
+repository-specific path from this skill.
+
+```bash
+actionlint -pyflakes=
+mapfile -t shell_files < <(rg --files -g '*.sh' -g '*.bash' .github)
+if ((${#shell_files[@]})); then
+  shellcheck "${shell_files[@]}"
+fi
+pinact run --check --min-age 7
+```
+
+If no shell files are present, rely on actionlint's inline script checks and
+record that the standalone ShellCheck pass had no targets.
+
+When updating action pins, keep the cooldown in the command:
+
+```bash
+pinact run --update --min-age 7
+```
+
+## Review Checklist
+
+- Workflow syntax and expressions were checked with actionlint.
+- Inline workflow shell scripts and standalone shell scripts were checked with
+  ShellCheck.
+- Third-party actions and reusable workflows were checked with pinact.
+- New executable artifacts satisfy the repository cooldown and pinning policy.
+- Permissions and secrets are least-privilege and documented when unusual.
+- Runner labels, variables, and suppressions are configured intentionally.
+- Local documentation and CI behavior describe the same quality checks.

--- a/.agents/skills/github-actions-quality-check/agents/openai.yaml
+++ b/.agents/skills/github-actions-quality-check/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "GitHub Actions Quality Check"
+  short_description: "Quality-check GitHub Actions workflows, pins, permissions, and CI linting."
+  default_prompt: >-
+    Quality-check this GitHub Actions change for workflow syntax, action
+    pinning, permissions, runner labels, triggers, concurrency, secrets, and
+    verification coverage.

--- a/.agents/skills/gitignore-workflow/SKILL.md
+++ b/.agents/skills/gitignore-workflow/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: gitignore-workflow
+description: "Create or update .gitignore files. Use when editing ignore rules."
+---
+
+# Gitignore Workflow
+
+## When to Use
+
+- Use this skill when creating or updating `.gitignore`.
+
+## Goals
+
+- Keep project-specific ignore rules explicit and easy to review.
+- Merge upstream template content from `github/gitignore` without losing local rules.
+- Record external-template provenance with commit-hash URLs for reproducibility.
+- Avoid introducing regressions, for example accidentally tracking generated files.
+- Support both minimal edits and full template refreshes.
+- Work across mixed-language repositories.
+
+## Workflow
+
+1. Inspect the current repository state before editing.
+2. Read the current `.gitignore` and classify entries as project-specific vs template-derived.
+3. If template sync is requested, treat the copied template content as supply-chain-sensitive
+   external material:
+   - Use `security-check` for network-fetch safety, source provenance, pinning, and any blocker
+     decision.
+4. Verify the upstream template source before fetching or copying:
+   - Confirm the exact repository, template path, and commit hash.
+   - Prefer reviewer-visible commit-hash URLs over branch, tag, or `latest` references.
+   - Report a blocker instead of fetching or copying when provenance or the safe network path
+     cannot be verified.
+5. Merge sections in a deterministic order requested by the user or a safe default order.
+6. Validate with `git status` that ignored/generated files behave as expected.
+7. Summarize behavior-impacting changes, especially `.env`, lockfiles, build artifacts, caches, and
+   IDE folders.
+
+## Recommended Section Order
+
+Use this structure when the user requests Python with project-local rules.
+For other stacks, keep the same pattern and swap template sections as needed.
+
+```text
+# Project specific files
+{project-specific ignore entries}
+
+# Agent worktree directory
+.agents/worktrees/
+# Agent reference directory
+.agents/references/
+
+# Python.gitignore
+# https://github.com/github/gitignore/blob/<commit-hash>/Python.gitignore
+{Python.gitignore content}
+```
+
+## Generalized Section Pattern
+
+For multi-stack repositories, repeat this pattern per template:
+
+```text
+# <TemplateName>.gitignore
+# https://github.com/github/gitignore/blob/<commit-hash>/<TemplatePath>
+{template content}
+```
+
+## Template Fetch Pattern
+
+Use network fetches only after the safety and provenance checks above pass.
+Pin the source to one reviewed commit hash and keep the command reviewer-visible.
+
+```bash
+hash=$(git ls-remote https://github.com/github/gitignore.git refs/heads/main | awk '{print $1}')
+curl -fsSL "https://raw.githubusercontent.com/github/gitignore/$hash/Python.gitignore"
+```
+
+For other templates, replace paths with exact file paths from `github/gitignore`.
+For example, use `Global/VisualStudioCode.gitignore`.
+If the command, source repository, template path, or commit hash cannot be verified, stop and report
+the blocker instead of fetching or copying template content.
+
+## Safety Checks
+
+- Do not remove project-specific entries unless explicitly requested.
+- Keep duplicate patterns if they come from upstream templates; avoid semantic edits to upstream blocks.
+- Preserve `.env` handling intentionally. If behavior changes, call it out in the summary.
+- Never include secrets or real environment values in `.gitignore` comments.
+- If files are already tracked, mention that `.gitignore` alone does not untrack them.
+- Avoid adding global ignores that could hide source files by mistake.
+
+## Output Checklist
+
+- `.gitignore` updated in requested format.
+- All upstream template URLs include commit hashes, exact paths, and reviewed provenance.
+- Network fetches were either avoided, performed through a pinned and verified source, or blocked
+  with the reason recorded.
+- `git status --short` reviewed after edits.
+- User summary includes what changed, why, and any follow-up commands if tracked files must be untracked.

--- a/.agents/skills/gitignore-workflow/agents/openai.yaml
+++ b/.agents/skills/gitignore-workflow/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "Gitignore Workflow"
+  short_description: "Create or update .gitignore files."
+  default_prompt: >-
+    Create or update .gitignore rules while preserving project-specific entries
+    and validating ignored file behavior, external-template provenance, and
+    pinned external-template sources.

--- a/.agents/skills/issue-quality-check/SKILL.md
+++ b/.agents/skills/issue-quality-check/SKILL.md
@@ -1,0 +1,222 @@
+---
+name: issue-quality-check
+description: >-
+  Quality-check repository issues and issue replies. Use when creating,
+  updating, reviewing, or validating GitHub issues or comments on issues.
+---
+
+# Issue Quality Check
+
+## When to Use
+
+- Use this skill when creating, updating, reviewing, or validating GitHub issue
+  titles or bodies for this repository.
+- Use this skill when creating, updating, reviewing, or validating replies or
+  comments on GitHub issues for this repository.
+
+## Goals
+
+- Make issue titles, bodies, and replies clear enough for maintainers to triage and act on.
+- Preserve required LLM disclosure alerts when issue text has significant LLM
+  assistance. For artifacts prepared by an AI agent in this workflow, treat the
+  assistance as significant and include the alert.
+- Keep issue text in English except for exact quoted source material or identifiers.
+- Prevent shell quoting from corrupting Markdown when creating or editing issues through `gh`.
+- Record verification limits, uncertainty, and requested follow-up information explicitly.
+
+## Workflow
+
+1. Classify the artifact as an issue title, issue body, issue reply, or combined issue update.
+2. Check required LLM disclosure first, using the issue-body alert for issues and the comment alert
+   for replies when LLM assistance was significant. For AI-agent-prepared artifacts, assume the
+   assistance is significant.
+3. Check the title when present for concise, specific triage wording.
+4. Check the body or reply structure, keeping only sections that add useful information.
+5. Check English style, concise wording, exact quoted material, and issue-specific nuance with
+   `document-quality-check` when explanatory prose needs review.
+6. Check risk-sensitive content with `security-check` when the issue mentions security,
+   supply-chain-sensitive tools, dependencies, CI, containers, secrets, permissions, or exceptions.
+7. Check CLI safety before creating or editing issues or replies through a shell command.
+8. After any `gh` create or edit command, verify the stored Markdown body or comment when possible,
+   fix quoting problems, and remove temporary body files.
+9. In CLI examples, use confirmed issue numbers, comment IDs, or placeholders such as
+   `<issue-number>`. Do not infer an issue number from a pull request number or unrelated context.
+
+## Title
+
+Check that the title is concise, specific, and written as a problem or task:
+
+- Prefer a clear noun phrase or imperative task, such as
+  `Add practice reset hotkey documentation` or
+  `Fix cruiser state reload after scene transition`.
+- Include the affected area when it helps triage, such as `MagnetService:` or `docs:`.
+- Avoid vague titles such as `Bug`, `Question`, `Help`, or `Does not work`.
+- Do not force Conventional Commits format for issues unless the repository
+  explicitly asks for it in that issue flow.
+
+## Required LLM Alert
+
+When the issue has significant LLM assistance, check that this GitHub alert
+appears at the very top of the issue body. For issue bodies prepared by an AI
+agent, assume the assistance is significant:
+
+```markdown
+> [!WARNING]
+> This issue was created with assistance from LLMs.
+```
+
+The alert should appear before every other heading, summary, checklist, template
+field, or metadata block.
+
+## Body Structure
+
+Check that the body is concise and uses these sections when applicable:
+
+```markdown
+> [!WARNING]
+> This issue was created with assistance from LLMs.
+
+## Summary
+- ...
+
+## Details
+- ...
+
+## Acceptance Criteria
+- ...
+```
+
+The example includes the LLM alert because this skill is usually used for
+AI-agent-prepared issue text. Omit the alert only when the issue has no
+significant LLM assistance.
+
+Recommend sections only when they carry useful information:
+
+- `Summary`: the problem, request, or outcome in maintainer-facing language.
+- `Details`: relevant context, reproduction notes, affected paths, logs, or constraints.
+- `Acceptance Criteria`: concrete checks that would make the issue complete.
+- `Verification`: commands, manual checks, or observations already performed.
+- `Notes`: limitations, related work, dependencies, or reviewer attention points.
+
+For follow-up issues, include durable origin context when useful, such as the pull request,
+review thread, issue, discussion, or investigation that caused the follow-up. When multiple related
+follow-up issues come from the same source, cross-link them in the issue bodies so future readers
+can trace the relationship without relying on transient comments elsewhere.
+
+## Style
+
+- Write issue titles, issue bodies, and issue comments in English.
+- Preserve non-English text only when quoting source text, branch names, commit messages, file
+  contents, logs, or existing discussion snippets that must remain exact.
+- Keep issue bodies short and scannable.
+- Use `document-quality-check` for explanatory prose.
+  - Preserve issue-specific nuance such as certainty, scope, timing, relationships, and whether a
+    statement is confirmed, inferred, untested, or unknown.
+- Use `security-check` when an issue or issue reply describes security-sensitive
+  behavior, supply-chain-sensitive tools, package runners, dependencies, CI actions, containers,
+  secrets, permissions, or security exceptions.
+- Prefer bullets for facts, steps, and criteria.
+- Mention paths, commands, classes, and config keys in backticks.
+- Include exact expected and actual behavior for bugs.
+- Include reproduction steps only when they are known and useful.
+- Do not paste large logs, stack traces, or diffs; summarize and link or attach details when needed.
+- Be explicit when verification or reproduction was not run.
+- Do not present AI-performed review, inspection, editing, verification, or
+  other work as "manual".
+
+## CLI Safety
+
+When creating or editing issue bodies with a shell command, avoid passing
+Markdown directly through command arguments if it contains backticks, quotes,
+dollar signs, backslashes, or multiple lines. Shells such as PowerShell and bash
+can interpret those characters and silently corrupt the body.
+
+- Prefer writing the body to a temporary Markdown file and passing it with
+  `gh issue create --body-file <file>` or `gh issue edit --body-file <file>`.
+- Use placeholders such as `<issue-number>` when the target issue number is unknown.
+- After creating or editing an issue through `gh`, verify the stored body with
+  `gh issue view --json body` and fix any quoting issues before finishing.
+- Remove any temporary body file from the worktree after verification.
+
+## Issue Replies
+
+When the issue reply has significant LLM assistance, check that this GitHub
+alert appears at the very top of the comment body. For replies prepared by an AI
+agent, assume the assistance is significant:
+
+```markdown
+> [!WARNING]
+> This comment was created with assistance from LLMs.
+```
+
+The alert should appear before every other paragraph, heading, checklist, quote,
+or metadata block.
+
+Check that the reply is concise and uses only the structure needed for the situation:
+
+```markdown
+> [!WARNING]
+> This comment was created with assistance from LLMs.
+
+Thanks for the report. I can reproduce this with ...
+
+## Next Steps
+- ...
+```
+
+The example includes the LLM alert because this skill is usually used for
+AI-agent-prepared replies. Omit the alert only when the reply has no significant
+LLM assistance.
+
+Recommend sections only when they carry useful information:
+
+- Opening sentence: acknowledge the report, question, or prior comment directly.
+- `Findings`: facts discovered from code, logs, reproduction, or maintainer investigation.
+- `Next Steps`: what will be done next, what is blocked, or what input is needed.
+- `Verification`: commands or manual checks run while investigating.
+- `Notes`: caveats, related issues, or constraints that should remain visible.
+
+For issue replies:
+
+- Keep replies focused on the current issue thread.
+- Answer direct questions before adding broader context.
+- Quote only the smallest useful part of a previous comment.
+- Mention paths, commands, classes, and config keys in backticks.
+- Be clear whether something is confirmed, inferred, untested, or still unknown.
+- Ask for specific missing information when needed, such as logs, package or
+  application versions, reproduction steps, or relevant data files.
+- Avoid large diffs, large logs, and unrelated implementation plans.
+- Do not promise timelines unless they are already agreed.
+- Do not present AI-performed review, inspection, editing, verification, or
+  other work as "manual".
+
+Use `Update Note` or `Discussion Note` sections only when the active task asks
+for process notes, decision logs, or granular issue-thread updates. Do not add
+them by default: frequent process notes can clutter the thread and may expose
+unnecessary implementation context. When enabled:
+
+- Use `Update Note` for a concrete issue, documentation, or implementation
+  update that was just made.
+- Use `Discussion Note` for a decision, tradeoff, or rationale that should
+  remain visible in the issue thread.
+- Immediately after the required LLM alert and before the note heading, add a
+  neutral `Request addressed: ...` line. Use it only as a concise marker for
+  later AI-disclosure or AI-assisted inspection summaries; do not use it to
+  classify requester identity, role, or authority.
+- Keep each note concise and limited to information that is safe and useful for
+  future readers.
+- Base notes on confirmed issue context. If a note includes an inference or
+  assumption, label it as such.
+- Do not include secrets, private discussion, local-only paths, hidden
+  chain-of-thought, or unrelated implementation details.
+- Prefer a normal short reply when the comment only needs to answer a question,
+  report investigation results, or acknowledge completion.
+
+When creating or editing issue replies with a shell command:
+
+- Prefer writing the reply to a temporary Markdown file and passing it with
+  `gh issue comment --body-file <file>`.
+- Use placeholders such as `<issue-number>` when the target issue number is unknown.
+- After creating or editing a reply through `gh`, verify the stored comment body
+  when possible and fix any quoting issues before finishing.
+- Remove any temporary body file from the worktree after verification.

--- a/.agents/skills/issue-quality-check/agents/openai.yaml
+++ b/.agents/skills/issue-quality-check/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "Issue Quality Check"
+  short_description: "Quality-check repository issues and issue replies."
+  default_prompt: >-
+    Quality-check this GitHub issue or issue reply for clarity, structure,
+    repository style, and required LLM disclosure.

--- a/.agents/skills/pull-request-quality-check/SKILL.md
+++ b/.agents/skills/pull-request-quality-check/SKILL.md
@@ -1,0 +1,202 @@
+---
+name: pull-request-quality-check
+description: Quality-check repository pull requests, review comments, replies, and PR-thread notes.
+---
+
+# Pull Request Quality Check
+
+## When to Use
+
+- Use this skill when creating, updating, reviewing, or validating pull request
+  titles, bodies, review comments, replies, or PR-thread notes.
+
+## Goals
+
+- Keep pull request communication accurate, reviewable, and aligned with the
+  repository's current PR template.
+- Preserve required LLM disclosure for PR bodies, reviews, replies, and
+  PR-thread notes. For artifacts prepared by an AI agent in this workflow, treat
+  the assistance as significant and include the alert.
+- Keep verification evidence separated by source so automated checks, manual
+  checks, CI, screenshots, and AI-assisted inspections are not confused.
+- Avoid shell quoting corruption when creating or editing Markdown through CLI
+  tools.
+
+## Workflow
+
+1. Identify the artifact being checked: PR title, PR body, review, reply, or
+   PR-thread note.
+2. For PR titles, verify the Conventional Commits-style title shape and use
+   `commit-message-quality-check` for type selection and breaking-change
+   notation.
+3. For PR bodies, read the current repository PR template before drafting or
+   replacing content. If no template exists, use the directly linked fallback
+   scaffold in [references/fallback-pr-body.md](references/fallback-pr-body.md).
+4. Check that the required LLM alert appears at the very top when the PR body,
+   review, reply, or PR-thread note has significant LLM assistance. For
+   AI-agent-prepared artifacts, assume the assistance is significant.
+5. Check that verification evidence is grouped under the right testing or
+   inspection category, with AI-assisted inspections labeled separately.
+6. Apply the style, PR-thread note, and CLI safety rules below.
+7. Re-read the final title, body, comment, or review as a maintainer would:
+   stale template text, invented checklist items, unclear verification, and
+   missing disclosure are blocking issues.
+
+## Title
+
+Check that the title uses a Conventional Commits-style format:
+
+```text
+<type>[optional scope][optional !]: <description>
+```
+
+Use `commit-message-quality-check` for type selection and breaking-change notation.
+
+Reference: https://www.conventionalcommits.org/en/v1.0.0/
+
+## Required LLM Alert
+
+When the PR has significant LLM assistance, check for this GitHub alert.
+For PR bodies prepared by an AI agent, assume the assistance is significant.
+The alert must appear at the very top of the PR body:
+
+```markdown
+> [!WARNING]
+> This pull request was created with assistance from LLMs.
+```
+
+The alert should appear before every other heading, summary, checklist, or
+metadata block.
+
+## Pull Request Template
+
+Before creating or replacing a pull request body, check for a repository pull
+request template.
+Use the first applicable template found in the normal GitHub locations, such as:
+
+- `.github/pull_request_template.md`
+- `.github/PULL_REQUEST_TEMPLATE.md`
+- `docs/pull_request_template.md`
+- `docs/PULL_REQUEST_TEMPLATE.md`
+- A user-selected file under `.github/PULL_REQUEST_TEMPLATE/` or `docs/PULL_REQUEST_TEMPLATE/`
+
+When a template exists:
+
+- Read the template file before drafting the body. Do not rely on memory,
+  previous PR bodies, or heading summaries.
+- Follow the template's visible headings, required checkboxes, and required-if-applicable sections.
+- Use HTML comments in the template as author guidance. Do not copy those
+  comments into the rendered PR body.
+- Keep required alerts, checklist confirmations, and section names compatible with the template.
+- Fill sections with `None` or `Not applicable` only when the template or
+  surrounding policy asks for an explicit value.
+- Do not replace template-specific headings with generic defaults. For example,
+  do not use `Verification` when the template uses `Testing`.
+- Do not add obsolete checklist items that are no longer present in the repository template.
+- Copy required checklist wording from the current template exactly. Change
+  unchecked boxes to checked boxes only when the author can truthfully confirm
+  the item.
+- When updating an existing PR body, remove or revise stale body text that
+  describes removed template items. For example, remove an old AI-disclosure
+  checkbox that no longer exists.
+- If the template should apply but the exact file or selected variant is
+  unavailable, stop and get the template. Do not invent placeholder headings or
+  checklist text.
+
+When no repository template exists, use
+[references/fallback-pr-body.md](references/fallback-pr-body.md). Keep its
+top-level headings, testing subsection order, and CLA checklist unless the
+repository policy explicitly says otherwise.
+
+## Verification Evidence
+
+- Do not present AI-performed review, inspection, editing, verification, or
+  other work as "manual".
+- If an AI-assisted inspection was requested, report it under a
+  `### AI-assisted inspections` subsection inside `## Testing`, after
+  `### Automated checks` when both sections are present.
+- In `### AI-assisted inspections`, use a short `Request: ...` line to
+  summarize the requested inspection. Nest the `AI-assisted result: ...` under
+  that request summary.
+- Keep automated commands, CI results, non-AI manual checks, screenshots,
+  videos, and AI-assisted inspection results distinct from each other.
+
+## Style
+
+- Write pull request titles, pull request bodies, review comments, and replies in English.
+- Preserve non-English text only when quoting source text, branch names, commit messages, file
+  contents, logs, or existing discussion snippets that must remain exact.
+- Keep PR bodies short and reviewable.
+- Use `document-quality-check` for explanatory prose that needs readability, structure, or nuance
+  review.
+- Use `security-check` when a pull request body, reply, or review note describes
+  security-sensitive behavior, supply-chain-sensitive tools, package runners, dependencies,
+  downloaded artifacts, CI actions, containers, secrets, permissions, or security exceptions.
+- Prefer bullets over long paragraphs.
+- Mention paths or commands in backticks.
+- Do not paste large diffs.
+- Be explicit when verification was not run.
+- Align the PR title type with the dominant change. For example, use `docs:`
+  for documentation-only skill additions and `refactor:` for behavior-preserving
+  code cleanup.
+
+## Pull Request Replies and Reviews
+
+When a pull request reply or review has significant LLM assistance, check for
+this GitHub alert. For replies, reviews, or PR-thread notes prepared by an AI
+agent, assume the assistance is significant.
+It must appear at the very top of the comment or review body:
+
+```markdown
+> [!WARNING]
+> This comment was created with assistance from LLMs.
+```
+
+The alert should appear before every other paragraph, heading, checklist, quote,
+finding, or metadata block.
+
+Use `Update Note`, `Discussion Note`, or `Review Note` sections only when the
+active task asks for process notes, decision logs, review summaries, or granular
+PR-thread updates. Do not add them by default. Frequent process notes can
+clutter the PR conversation and may expose unnecessary implementation context.
+When enabled:
+
+- Use `Update Note` for a concrete change that was just made to the pull request.
+- Use `Discussion Note` for a decision, tradeoff, or rationale that should
+  remain visible in the PR thread.
+- Use `Review Note` when reporting a review pass, consistency check, readiness
+  check, or retrospective verification that did not itself make a concrete
+  change.
+- If the active task asks for "history so far", "notes so far", or similar
+  retrospective PR-thread notes, do not dump raw commit history. Create separate
+  concise notes grouped by meaningful decision or change theme, using
+  `Update Note` for concrete PR changes and `Discussion Note` for decisions,
+  tradeoffs, or rationale.
+- If the requester asks for notes to be separate, or a correction includes two
+  independently reviewable changes, post separate PR comments for each theme
+  instead of combining them into one broad note.
+- Immediately after the required LLM alert and before the note heading, add a
+  neutral `Request addressed: ...` line. Use it only as a concise marker for
+  later PR-body `### AI-assisted inspections` summaries; do not use it to
+  classify requester identity, role, or authority.
+- Keep each note concise and limited to information that is safe and useful for
+  future reviewers.
+- Base notes on confirmed PR context. If a note includes an inference or
+  assumption, label it as such.
+- Do not include secrets, private discussion, local-only paths, hidden
+  chain-of-thought, or unrelated implementation details.
+- Prefer a normal short reply when the comment only needs to answer a question,
+  report review results, or acknowledge completion.
+
+## CLI Safety
+
+When creating or editing PR bodies with a shell command, avoid passing Markdown
+directly through command arguments. Backticks, quotes, dollar signs, backslashes,
+and multiple lines are easy to corrupt in shell arguments. Shells such as
+PowerShell and bash can interpret those characters silently.
+
+- Prefer writing the body to a temporary Markdown file. Pass it with
+  `gh pr create --body-file <file>` or `gh pr edit --body-file <file>`.
+- After creating or editing a PR through `gh`, verify the stored body with
+  `gh pr view --json body`. Fix any quoting issues before finishing.
+- Remove any temporary body file from the worktree after verification.

--- a/.agents/skills/pull-request-quality-check/SKILL.md
+++ b/.agents/skills/pull-request-quality-check/SKILL.md
@@ -105,8 +105,8 @@ When a template exists:
 
 When no repository template exists, use
 [references/fallback-pr-body.md](references/fallback-pr-body.md). Keep its
-top-level headings, testing subsection order, and CLA checklist unless the
-repository policy explicitly says otherwise.
+top-level headings and testing subsection order unless the repository policy
+explicitly says otherwise.
 
 ## Verification Evidence
 

--- a/.agents/skills/pull-request-quality-check/agents/openai.yaml
+++ b/.agents/skills/pull-request-quality-check/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "Pull Request Quality Check"
+  short_description: "Quality-check repository pull requests."
+  default_prompt: >-
+    Quality-check this pull request title, body, reply, or review for repository
+    style, structure, verification notes, and required LLM disclosure.

--- a/.agents/skills/pull-request-quality-check/references/fallback-pr-body.md
+++ b/.agents/skills/pull-request-quality-check/references/fallback-pr-body.md
@@ -1,0 +1,134 @@
+# Fallback Pull Request Body
+
+Use this fallback only when the repository has no applicable pull request
+template. If a repository template exists, the live template takes precedence.
+Use the pull request template section guidance in
+`CONTRIBUTING.md#pull-requests`.
+
+## Contents
+
+- [Fallback Scaffold](#fallback-scaffold)
+
+## Fallback Scaffold
+
+Keep the fallback structure aligned with `.github/pull_request_template.md`.
+When a scaffold subsection has no applicable content, write `None` or
+`Not applicable` instead of removing the heading.
+
+````markdown
+<!--
+If significant AI assistance affected this pull request, put this alert at the
+very top of the PR body:
+
+> [!WARNING]
+> This pull request was created with assistance from LLMs.
+
+Then describe the AI assistance under "AI disclosure" below.
+-->
+
+## Summary
+
+<!--
+Briefly describe what changed, who it affects, and why it is useful.
+If this pull request mixes unrelated behavior, documentation, refactors, or
+cleanup, split it or explain why the work should stay together.
+If the title or commits include `!` or `BREAKING CHANGE`, include a
+`### Breaking Changes` subsection.
+Treat a change as breaking when it removes, renames, or incompatibly changes
+public behavior, documented workflows, configuration, package or release
+behavior, compatibility guarantees, or other project-facing contracts that
+users, maintainers, automation, or downstream packaging reasonably rely on.
+
+Optional H3 examples:
+### User impact
+### Contributor impact
+### Maintainer impact
+### Breaking Changes
+-->
+
+## Related Issues
+
+<!--
+Prefer Markdown list items for GitHub issues or pull requests so GitHub can
+render rich references.
+Use closing keywords, such as "Closes #123", when this pull request should
+close an issue.
+For non-GitHub references, include enough context for reviewers to understand
+why the link matters.
+Use "None" if there is no related issue.
+
+Markdown list examples:
+- Closes #123
+- Refs #456
+- Refs owner/repository#789
+-->
+
+## Notes for reviewers
+
+<!--
+Share non-testing context that helps reviewers understand or prioritize this
+pull request.
+For example, mention review focus, trade-offs, compatibility risks,
+generated outputs, packaging concerns,
+or areas that need extra attention for reasons other than AI assistance.
+-->
+
+### AI disclosure
+
+<!--
+If AI assistance significantly affected this pull request, disclose it here.
+Mention what the AI helped with, how you reviewed or adapted the result, and
+any AI-assisted areas you did not review closely.
+Use "None" if no significant AI assistance was used.
+
+Optional H3 examples:
+### Review focus
+### Lower-confidence areas
+-->
+
+## Testing
+
+<!--
+List the checks you ran and their results.
+Include commands, manual in-game checks, screenshots, or videos when relevant.
+For docs-only changes, mention proofreading, link checks, formatting checks,
+or "Not run - docs only."
+If you did not run a relevant check, explain why.
+You are responsible for masking personal information, local absolute paths,
+access tokens, and other sensitive details before posting logs, screenshots,
+or videos.
+Do not present AI-performed review, inspection, editing, verification, or other
+work as "manual". For example, if you include AI-assisted inspection, list a
+short `Request: ...` summary first, nest the `AI-assisted result: ...` under it,
+and clearly label the result as AI-assisted.
+
+Optional testing structure:
+### Build log
+
+<details>
+
+```plain
+$ DOTNET_CLI_UI_LANGUAGE=en dotnet build
+Paste the relevant output here.
+```
+
+</details>
+
+### Automated checks
+### AI-assisted inspections
+### Manual checks
+### Screenshots / videos
+-->
+
+## Checklist
+
+<!--
+Check this item before submitting.
+Pull requests cannot be merged without Contribution License Agreement
+confirmation.
+-->
+
+As the pull request author, I have checked all required items:
+
+- [ ] I have read `CONTRIBUTING.md` and agree to the Contribution License Agreement.
+````

--- a/.agents/skills/pull-request-quality-check/references/fallback-pr-body.md
+++ b/.agents/skills/pull-request-quality-check/references/fallback-pr-body.md
@@ -90,7 +90,7 @@ Optional H3 examples:
 
 <!--
 List the checks you ran and their results.
-Include commands, manual in-game checks, screenshots, or videos when relevant.
+Include commands, manual browser checks, screenshots, or videos when relevant.
 For docs-only changes, mention proofreading, link checks, formatting checks,
 or "Not run - docs only."
 If you did not run a relevant check, explain why.

--- a/.agents/skills/pull-request-quality-check/references/fallback-pr-body.md
+++ b/.agents/skills/pull-request-quality-check/references/fallback-pr-body.md
@@ -106,7 +106,7 @@ Optional testing structure:
 <details>
 
 ```plain
-$ DOTNET_CLI_UI_LANGUAGE=en dotnet build
+$ <build or verification command>
 Paste the relevant output here.
 ```
 

--- a/.agents/skills/pull-request-quality-check/references/fallback-pr-body.md
+++ b/.agents/skills/pull-request-quality-check/references/fallback-pr-body.md
@@ -2,8 +2,6 @@
 
 Use this fallback only when the repository has no applicable pull request
 template. If a repository template exists, the live template takes precedence.
-Use the pull request template section guidance in
-`CONTRIBUTING.md#pull-requests`.
 
 ## Contents
 
@@ -119,16 +117,4 @@ Paste the relevant output here.
 ### Manual checks
 ### Screenshots / videos
 -->
-
-## Checklist
-
-<!--
-Check this item before submitting.
-Pull requests cannot be merged without Contribution License Agreement
-confirmation.
--->
-
-As the pull request author, I have checked all required items:
-
-- [ ] I have read `CONTRIBUTING.md` and agree to the Contribution License Agreement.
 ````

--- a/.agents/skills/release-note-workflow/SKILL.md
+++ b/.agents/skills/release-note-workflow/SKILL.md
@@ -1,0 +1,236 @@
+---
+name: release-note-workflow
+description: >-
+  Create, update, or review user-facing release notes. Use when deriving stable
+  release notes from a canonical changelog or checking release-note readiness
+  before publication.
+---
+
+# Release Note Workflow
+
+## When to Use
+
+- Use this skill when preparing or reviewing user-facing release notes.
+- Use this skill when deriving stable release notes from canonical
+  changelog entries.
+- Use this skill when checking release-note readiness before publication.
+
+## Goals
+
+- Keep the user-facing release-note file as the cumulative stable release
+  history, with the latest stable release at the top.
+- Derive release notes from the canonical developer changelog instead of making
+  a second source of truth.
+- Rewrite stable release notes for users, focusing on behavior, installation,
+  compatibility, update impact, known limitations, and security.
+- Include a concise reason or background sentence for each user-visible change
+  so users can understand why the change was made or why it affects them.
+- Make version, source material, publication-channel requirements, and release
+  readiness explicit before publication.
+
+## Workflow
+
+1. Locate the canonical developer changelog, user-facing release-note file,
+   release version source, publication channel, release workflow, and
+   verification command from repository evidence such as docs, configs, scripts,
+   or workflow files. Report anything undiscoverable as a missing input or
+   blocker.
+   - Prefer evidence in this order: explicit maintainer input, release or
+     publication docs, existing release-note history, workflow or config
+     behavior, then scripts or source metadata.
+   - When multiple candidate version sources, publication channels, tag
+     conventions, or workflows conflict, report all candidates and treat the
+     conflict as a blocker unless repository docs establish precedence.
+   - Separate the discovered publication channel from the channel's release-note
+     format requirements. If the channel is known but its required format is
+     not, report the missing format as a blocker or required maintainer action.
+     Do not infer format requirements from the channel name alone; use
+     maintained docs, existing release-note history, workflow/config behavior,
+     or maintainer input.
+   - Use read-only evidence gathering for readiness reviews. Useful examples
+     include reading version metadata, listing local tags with `git tag --list`,
+     checking remote tags with `git ls-remote --tags <remote>`, inspecting
+     workflow or release scripts for release-note inclusion, and reading docs
+     for verification commands.
+2. Read the exact stable release section in the canonical developer changelog.
+   - If the exact canonical section is unavailable, write draft release notes
+     and list the missing inputs instead of presenting the output as final.
+   - If the UTC release date is missing, keep the output clearly marked as
+     draft review text. Do not create a release-ready heading with `TBD`,
+     `<date>`, or similar placeholder release metadata.
+3. Confirm the release is stable:
+   - Stable releases use a version without a prerelease suffix, such as
+     `1.2.3`.
+   - Prerelease versions, such as `1.2.3-alpha.1`, remain developer-facing and
+     are not published as stable user-facing notes unless the publication
+     channel explicitly supports prerelease notes.
+   - Do not infer an intended stable version from a prerelease version without
+     maintainer confirmation.
+   - Accept prerelease support only from maintained publication-channel policy,
+     release documentation, explicit maintainer input, or existing release-note
+     history.
+4. Roll prerelease entries into the next stable release when they still affect
+   stable users.
+5. Omit prerelease-only details from the user-facing release notes when
+   they were internal, superseded before stable release, or useful only to
+   maintainers.
+   - When mentioning work that happened during a prerelease cycle in stable
+     user-facing notes, prefer the stable release timing or stable version
+     wording unless the prerelease identifier is user-visible and necessary.
+     Keep exact prerelease identifiers in the canonical developer changelog.
+6. Rewrite the stable entries around user-visible behavior, installation,
+   compatibility, update impact, security, and known limitations.
+   - Use `document-quality-check` for explanatory prose. Preserve
+     release-note-specific nuance such as compatibility confidence, dependency
+     relationships, and whether context is original, backfilled, inferred,
+     superseded, or withdrawn.
+7. For each user-visible change, include one concise reason or background
+   sentence from the canonical changelog or maintainer input.
+   - Apply this requirement to the target release being prepared or reviewed.
+     Improve older cumulative entries when they are touched, but do not block
+     the target release only because untouched historical entries lack
+     rationale.
+   - Good source material includes the user problem being solved, why behavior
+     changed, compatibility or migration constraints, known limitation context,
+     or why a release was yanked.
+   - A sourced user impact statement can serve as the reason/background sentence
+     only when it explains why users should care.
+   - Use conservative negative-impact summaries, such as "no gameplay changes",
+     only when the canonical changelog or maintainer input supports that
+     conclusion for the target release.
+   - Generic source bullets such as documentation updates, dependency updates,
+     crash fixes, or save-format changes are draft-only until the canonical
+     changelog or maintainer input explains the user-facing benefit, risk,
+     security impact, compatibility impact, or migration reason.
+   - If a change lacks enough rationale or history, mark it as draft or a
+     missing input instead of inventing an explanation.
+8. Preserve user-critical notes in the user-facing release notes,
+   including breaking changes, compatibility changes, installation or update
+   notes, removals, deprecations, security fixes, yanked releases, and known
+   limitations.
+   - Use `security-check` when security-sensitive or supply-chain-sensitive release
+     content needs review. Include maintainer-confirmed security impact, residual risk, or
+     exception wording only when the canonical changelog or maintainer input supports it.
+   - If user-facing notes backfill historical compatibility or limitation
+     context for older releases, state that the information was added while
+     preparing the relevant stable release. Avoid wording that makes the
+     backfilled information sound like an original claim from the older
+     release.
+   - If a yanked release intentionally does not receive backfilled
+     compatibility or limitation information, say so when neighboring releases
+     do receive backfilled notes.
+9. Keep test environment details in the canonical developer changelog. Include
+   them in user-facing release notes only when they are needed as
+   user-facing compatibility or support context.
+   - Use maintainer-confirmed compatibility metadata from the canonical
+     changelog, prior release notes, tested product/dependency versions, or
+     explicit maintainer input. Do not invent compatibility claims.
+   - Place user-facing supplemental metadata under a `Notes` section, with
+     labeled bullets such as `Compatibility:` or `Known limitations:`, instead
+     of creating standalone headings for metadata that is not a Keep a
+     Changelog change category.
+   - Preserve useful confidence differences in compatibility notes. Distinguish
+     confirmed compatibility from best-effort "appears to work" notes,
+     lower-confidence limited checks, and known issues.
+   - Group companion tools, paired plugins, or required dependencies under the
+     product/version they were tested with when that relationship matters for
+     users.
+   - Put `Notes` after all change-category sections within each release entry
+     unless the publication channel explicitly requires another order.
+10. Before publication, verify:
+   - The user-facing release-note file has a stable version heading at
+     the top, not `Unreleased`, and does not contain placeholder release
+     metadata such as `TBD`.
+   - The release version source contains the intended stable version.
+   - The intended release version is not already present in a way that would
+     collide with the planned stable release.
+   - The intended stable tag, using the repository's documented tag convention,
+     does not already exist locally or remotely. Existing versions or tags are
+     blockers for stable publication until the maintainer chooses a new version
+     or a documented edge-release path. If remote tag verification cannot be
+     performed, report it as a release-readiness blocker.
+   - The release workflow will publish or include the user-facing release-note
+     file in the intended destination.
+   - Manual publication is allowed, but report it as a manual workflow state
+     and required maintainer action unless docs confirm automated inclusion.
+   - Undocumented publication or a missing user-facing release-note destination
+     is a blocker until docs or maintainer input confirm where release notes are
+     published and how they are included.
+   - The repository's documented build, release-note, or publication
+     verification succeeds after any related changes.
+
+## Review-Only Output
+
+When the user asks for a release-readiness review instead of edits, do not edit
+files. Return:
+
+1. Current state of the user-facing release-note file, source changelog section,
+   release version, local and remote tag readiness, publication-channel
+   requirements, and release workflow inclusion.
+2. Required updates before publication.
+3. Blockers or missing inputs, especially stable version, UTC release date,
+   exact canonical changelog text, and compatibility metadata.
+4. Confirmation that no publishing side effects were performed.
+
+For hypothetical readiness reviews, use explicit scenario facts or
+maintainer-provided facts as the highest-priority evidence, even when they
+conflict with the current checkout.
+
+For readiness reviews, include a compact status matrix covering:
+
+- Source changelog section.
+- User-facing release-note destination.
+- Version source and discovered version.
+- Tag convention, intended tag, local tag state, and remote tag state.
+- Publication channel and required release-note format.
+- Release workflow inclusion.
+- Verification command and result, or the missing verification input.
+
+Classify review items as:
+
+- `Blocker`: prevents release-ready notes or publication readiness.
+- `Required update`: must be changed before publication but has a clear owner
+  and path.
+- `Required maintainer action`: needs maintainer confirmation or manual action.
+- `Informational`: useful context that does not block readiness.
+
+## Output Shape
+
+- Release-ready stable notes use the publication channel's required heading
+  format with a confirmed stable version and UTC release date.
+- User-facing supplemental metadata that is not itself a change type, such as
+  compatibility notes or known limitations, appears under `Notes` with labeled
+  bullets. Do not use standalone `Compatibility`, `Test Environment`, or
+  similar metadata headings unless the publication channel explicitly requires
+  them.
+- `Notes` appears after all change-category sections within each release entry
+  unless the publication channel explicitly requires another order.
+- Each user-visible change includes one concise reason or background sentence,
+  sourced from the canonical changelog or maintainer input.
+  This applies to the target release; untouched historical entries in a
+  cumulative file are not blockers solely because they predate this rule.
+- User-facing release-note files may include a short intro that identifies them
+  as user-facing notes and points readers to the canonical developer changelog
+  for internal implementation details, when both files are published or
+  discoverable.
+- Draft notes are clearly labeled as draft review text and list missing inputs
+  before any proposed user-facing wording.
+- Blockers name the missing or failed readiness item directly, such as stable
+  metadata, user-facing release-note destination, tag convention, local or
+  remote tag availability, publication channel, release workflow inclusion, or
+  verification command.
+
+## Boundaries
+
+- This skill owns user-facing release notes and release-note readiness,
+  not canonical developer changelog authoring.
+- Use `changelog-workflow` first when the canonical developer changelog itself
+  needs new entries or version-section changes.
+- This skill may review publishing and tag readiness, but it does not perform
+  publishing, release creation, or tag creation. Use a dedicated publishing or
+  release workflow for those side effects.
+- Treat missing stable metadata, missing tag convention, failed local or remote
+  tag verification, missing publication-channel requirements, and missing
+  prerelease-support evidence as release-readiness blockers.
+- Keep private workspace paths, temporary worktree names, command transcripts,
+  and authentication details out of public release-note text.

--- a/.agents/skills/release-note-workflow/SKILL.md
+++ b/.agents/skills/release-note-workflow/SKILL.md
@@ -95,7 +95,7 @@ description: >-
      or why a release was yanked.
    - A sourced user impact statement can serve as the reason/background sentence
      only when it explains why users should care.
-   - Use conservative negative-impact summaries, such as "no gameplay changes",
+   - Use conservative negative-impact summaries, such as "no user-visible behavior changes",
      only when the canonical changelog or maintainer input supports that
      conclusion for the target release.
    - Generic source bullets such as documentation updates, dependency updates,

--- a/.agents/skills/release-note-workflow/agents/openai.yaml
+++ b/.agents/skills/release-note-workflow/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "Release Note Workflow"
+  short_description: "Derive user-facing stable release notes."
+  default_prompt: >-
+    Derive or review stable user-facing release notes from canonical changelog
+    entries, then check version, tag, publication-channel, workflow, and
+    verification readiness.

--- a/.agents/skills/security-check/SKILL.md
+++ b/.agents/skills/security-check/SKILL.md
@@ -1,0 +1,171 @@
+---
+name: security-check
+description: >-
+  Check repository work for practical security risks, including secrets,
+  permissions, unsafe defaults, ad hoc executable tools, dependencies,
+  downloaded artifacts, CI actions, containers, vendored files, and
+  supply-chain-sensitive changes.
+---
+
+# Security Check
+
+## When to Use
+
+- Use this skill when repository work touches security-sensitive behavior,
+  external executable artifacts, dependency provenance, CI permissions,
+  containers, secrets, credentials, network access, generated artifacts,
+  vendored files, unsafe defaults, or user-provided data.
+- Use this skill when another workflow asks for a security review, a
+  supply-chain baseline check, or a decision about whether a tool can be run or
+  adopted safely.
+- Use this skill with `code-quality-check` for implementation changes and with
+  `skill-quality-check` for Agent Skill changes that describe security behavior.
+
+## Goals
+
+- Provide a single repository-local security reference point for agents and
+  maintainers.
+- Treat this guidance as a practical project baseline, not permission to take a
+  less safe path than a tool, platform, organization policy, package manager, or
+  current general security practice requires.
+- Prefer source-backed, version-aware, reviewer-visible decisions over
+  convenient but unverified execution.
+- Keep ecosystem-specific implementation details in dedicated follow-up work
+  when the repository cannot reasonably verify or maintain them here.
+- Do not treat out-of-scope ecosystem trust infrastructure as permission to
+  skip practical trust checks that current tools, platforms, organizations, or
+  general security practice expect agents to perform.
+- Record blockers, residual risk, and maintainer-approved exceptions clearly.
+
+## Workflow
+
+1. Identify the security-sensitive surface:
+   - Secrets, credentials, tokens, private data, or logs.
+   - Permission boundaries, CI permissions, publishing credentials, or
+     filesystem/network access.
+   - User-provided input, deserialization, file paths, shell commands, or
+     remote APIs.
+   - Dependencies, package-runner invocations, downloaded CLI tools, CI
+     actions, containers, vendored artifacts, generated code, or copied files.
+2. Check the strongest applicable rule first:
+   - Follow Codex, Claude Code, GitHub Copilot, platform, organization,
+     package-manager, and current general security requirements when they are
+     stricter or safer than this repository guidance.
+   - Treat repository-local guidance as the floor. It must not lower stronger
+     external requirements.
+   - When guidance conflicts, lags behind, or is uncertain, choose the stricter
+     or safer path and report the reason.
+3. Prefer safe defaults:
+   - Use least privilege for credentials, CI tokens, filesystem access, network
+     access, and service permissions.
+   - Avoid logging secrets, private paths, personal data, tokens, or sensitive
+     request and response bodies.
+   - Avoid broad shell execution, mutable global state, insecure temporary
+     files, untrusted archive extraction, and implicit remote-code execution
+     unless the controls are explicit and reviewed.
+   - Disable network access or sandbox execution where the workflow and tooling
+     reasonably allow it.
+4. Handle suspected security vulnerabilities carefully:
+   - Do not post exploit details, reproduction steps, secret values, vulnerable
+     endpoints, private data, or other sensitive security details in public
+     issues, pull requests, social media, livestreams, videos, or similar
+     public channels.
+   - Look for the repository's private reporting path, such as `SECURITY.md`,
+     GitHub private vulnerability reporting, a draft security advisory, or a
+     maintainer-provided contact method.
+   - Report suspected security issues to the maintainer through a private and
+     secure channel when possible, or to a trusted security organization when a
+     maintainer channel is unavailable.
+   - In public repository work, use only a minimal non-sensitive note when a
+     security issue exists, is blocked, or has been reported privately.
+5. For supply-chain-sensitive work, apply the supply-chain baseline below.
+6. If the safe path cannot be verified, do not normalize the risky action:
+   - Report a blocker when release age, provenance, runtime behavior, or
+     cooldown compliance cannot be verified.
+   - Record residual risk when a partially controlled path remains.
+   - Require a documented maintainer exception before proceeding with a weaker
+     path.
+7. Before recommending an exact safer command, inspect repository scripts,
+   lockfiles, and tool configuration so the recommendation is grounded in the
+   project instead of inventing a new ad hoc path.
+8. Record what was checked:
+   - Sources consulted and why they were sufficient or insufficient.
+   - Exact versions, refs, tags, digests, hashes, or lockfile entries reviewed.
+   - Commands that were run or intentionally skipped.
+   - Whether sensitive security details were withheld from public channels and
+     reported privately when applicable.
+   - Follow-up issues for ecosystem-specific controls that exceed this
+     general security skill.
+
+## Supply-Chain Baseline
+
+- Treat new or updated third-party packages, package-runner invocations,
+  downloaded CLI tools, GitHub Actions, containers, vendored artifacts,
+  generated code from external tools, copied files, and dependency lockfile
+  updates as supply-chain-sensitive.
+- Include direct and transitive dependencies when they are resolved by a
+  lockfile, package manager, container image, generated artifact, or vendored
+  bundle. Do not limit the review to direct dependency declarations when the
+  resolved graph is available.
+- Require a minimum 7-day cooldown before adopting newly released third-party
+  packages, downloaded binaries, CI actions, containers, or other external
+  executable artifacts unless the user or maintainer explicitly approves an
+  exception.
+- Treat cooldown as a minimum gate, not as proof that an external artifact is
+  trustworthy after the waiting period. Continue to evaluate provenance,
+  pinning, runtime behavior, permissions, vulnerability signals, and stricter
+  current security requirements before running or adopting it.
+- Prefer pinned, reviewable versions over floating references such as `latest`,
+  default branches, unpinned images, or implicit package-runner resolution.
+- Verify release age and provenance from source-backed evidence such as package
+  registry metadata, release pages, tags, changelogs, signed artifacts,
+  lockfiles, upstream commit history, or maintained package-manager docs.
+- Treat package runners as remote-code-execution paths until the exact command
+  form is verified:
+  - Confirm the package-manager version supports the needed cooldown or trust
+    policy.
+  - Confirm the exact configuration path, CLI flag, or environment variable
+    used by that command form.
+  - Confirm the policy applies before downloading or executing the package.
+  - Use source-backed and preferably test-backed evidence before documenting
+    `npx`, `npm exec`, `pnpm dlx`, or similar commands as acceptable.
+- Do not treat hash pinning alone as sufficient trust when the pinned artifact
+  can fetch or execute additional remote content at runtime, such as online
+  installers, bootstrappers, package runners, remote API clients, or tools with
+  plugin auto-download behavior.
+- Prefer safer execution methods when available:
+  - Already configured project tools or lockfile-backed dependencies.
+  - Cooldown enforcement that is version-aware and verified for the exact
+    command.
+  - Pinned and provenance-reviewed container images.
+  - Pinned, hash-verified artifacts with reviewed runtime behavior.
+  - Disabled network access, sandboxing, and least-privilege execution.
+  - Reviewer-visible commands and configuration.
+- If release age, provenance, runtime behavior, or cooldown compliance cannot
+  be verified, report a blocker instead of trying an unverified fetch-and-run
+  command.
+
+## Maintenance
+
+- Re-check current tool behavior, package-manager documentation, platform
+  policies, organization policies, and general security practice when making a
+  security-sensitive decision.
+- Update this skill when it falls behind safer current practice.
+- Create or link follow-up issues when a safer current practice is identified
+  but concrete ecosystem-specific implementation work belongs outside this
+  general guidance.
+
+## Output Checklist
+
+- The security-sensitive surface was identified, or the change was classified
+  as not security-sensitive with a reason.
+- Stricter external requirements were followed when applicable.
+- Supply-chain-sensitive artifacts satisfied cooldown, pinning, provenance, and
+  runtime-behavior checks, or blockers/residual risk were recorded.
+- Secrets, permissions, unsafe defaults, and untrusted input paths were checked
+  when relevant.
+- Suspected vulnerabilities were kept out of public channels when sensitive
+  details were involved, with private maintainer or trusted-organization
+  reporting used when appropriate.
+- Any maintainer exception is documented in the final summary, issue comment,
+  PR body, or review note.

--- a/.agents/skills/security-check/agents/openai.yaml
+++ b/.agents/skills/security-check/agents/openai.yaml
@@ -1,0 +1,8 @@
+interface:
+  display_name: "Security Check"
+  short_description: "Review repository work for practical security and supply-chain-sensitive risks."
+  default_prompt: >-
+    Review this repository work for practical security risks, including
+    secrets, permissions, unsafe defaults, supply-chain-sensitive artifacts,
+    ad hoc executable tools, dependencies, CI actions, containers, and
+    reviewer-visible blockers or residual risk.

--- a/.agents/skills/skill-quality-check/SKILL.md
+++ b/.agents/skills/skill-quality-check/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: skill-quality-check
+description: >-
+  Quality-check Agent Skills for trigger clarity, scope, structure, progressive
+  disclosure, domain separation, validation, and scenario-readiness. Use when
+  creating, updating, reviewing, or splitting Agent Skills, SKILL.md files, skill
+  references, bundled scripts, or skill metadata.
+---
+
+# Skill Quality Check
+
+## When to Use
+
+- Use this skill when creating, updating, or reviewing an Agent Skill.
+- Use this skill before committing changes to any `SKILL.md`, `references/`, `scripts/`,
+  `assets/`, or `agents/openai.yaml` file inside a skill folder.
+- Use this skill with scenario-based validation after creating or substantially revising a skill.
+
+## Goals
+
+- Keep each skill focused on one reusable job with clear trigger boundaries.
+- Make `description` concise, specific, and useful for implicit skill selection.
+- Keep `SKILL.md` lean: core workflow in the body, detailed variants in directly linked
+  `references/`, deterministic helpers in `scripts/`, reusable output materials in `assets/`.
+- Separate project-specific or domain-specific knowledge into dedicated domain skills or reference
+  files instead of mixing it into general workflow skills.
+- Use `security-check` when a skill describes security-sensitive behavior, external
+  executable artifacts, dependencies, CI actions, containers, vendored files, secrets, permissions,
+  unsafe defaults, or supply-chain policy.
+- Preserve a consistent top-level structure: `When to Use`, `Goals`, and `Workflow` unless a local
+  skill has a stronger established pattern.
+- Require scenario-based validation for new or materially revised skills.
+
+## Workflow
+
+1. Read the changed skill files and nearby related skills.
+2. Check description/body consistency before scenario validation:
+   - Compare the `description` trigger promise with the scope actually covered by `SKILL.md`.
+   - Reconcile any mismatch before treating scenario results as reliable.
+   - State whether adjacent scopes, such as publishing, deployment, or side-effecting operations,
+     are in scope, guidance-only, or require explicit confirmation.
+3. Check frontmatter:
+   - `name` uses lowercase letters, digits, and hyphens.
+   - `description` states what the skill does and when to use it.
+   - Trigger words are front-loaded enough to survive shortened skill lists.
+4. Check scope:
+   - One primary job per skill.
+   - No unrelated project policy, domain knowledge, or historical notes in a general-purpose skill.
+   - Split domain knowledge into a dedicated skill or a directly linked reference file when it would
+     otherwise make the skill broad or stale.
+   - Reference `security-check` instead of duplicating partial security or supply-chain
+     policy unless the target skill owns a narrower implementation detail.
+5. Check structure:
+   - Prefer `When to Use`, `Goals`, and `Workflow` for Agent Skills.
+   - Keep required steps explicit, ordered, and written as imperatives.
+   - Match specificity to risk: flexible guidance for judgment-heavy work, exact commands or scripts
+     for fragile operations.
+   - Use `document-quality-check` for explanatory prose. Preserve
+     skill-specific nuance such as trigger boundaries, scope, ordering, risk
+     level, and domain separation.
+6. Check progressive disclosure:
+   - Keep `SKILL.md` short enough to scan quickly.
+   - Link every optional reference directly from `SKILL.md`; avoid nested reference chains.
+   - Add a table of contents to reference files longer than 100 lines.
+   - Do not duplicate detailed guidance between `SKILL.md` and references.
+7. Check bundled resources:
+   - Include `scripts/` only for repeatable or fragile automation, and test representative scripts.
+   - Include `assets/` only for files used in outputs.
+   - Remove placeholder or auxiliary files that do not directly support the skill.
+8. Check metadata alignment:
+   - Check every changed skill folder for `agents/openai.yaml`. For new skills, create it unless
+     the repository has an explicit reason to omit app metadata for that skill.
+   - Treat a missing `agents/openai.yaml` as a blocking gap, not as an optional follow-up.
+   - Keep `agents/openai.yaml` aligned with `SKILL.md` trigger wording, scope, and expected output.
+   - Include `interface.display_name`, `interface.short_description`, and
+     `interface.default_prompt` when creating app metadata.
+   - Update or remove metadata that no longer directly supports the skill.
+9. Validate and iterate:
+   - Run the available skill validator, if the project has one.
+   - Run spelling, formatting, or project checks appropriate to Markdown-only changes.
+   - For each new or substantially revised skill, prepare two or three realistic validation
+     scenarios before evaluation, including at least one median case and one edge or out-of-scope
+     case.
+   - Give each scenario at least one critical requirement and evaluate with a fresh executor.
+   - Record unclear points, discretionary fill-ins, and repeated failure patterns.
+   - Apply one related theme of fixes per iteration.
+   - Stop only after convergence, divergence, or a stated resource cutoff. Treat convergence as two
+     consecutive rounds with no new unclear points and no meaningful accuracy or effort improvement.
+10. Record verification:
+   - Note external sources consulted, why they were needed, and how their guidance was applied.
+   - Note that each changed skill folder has `agents/openai.yaml`, or explain the repository policy
+     that intentionally omits it.
+   - Note whether `security-check` was used for security-sensitive skill content.
+   - Note whether docs, changelog, PR notes, or follow-up domain skills are needed.
+
+When validating with scenarios, keep the report categories separate:
+
+- **Target skill findings**: problems in the skill being reviewed, such as
+  description/body mismatch, repository-specific leakage, stale metadata,
+  missing validation, or unsupported bundled files.
+- **Input gaps**: unavailable source files, exact command text, unknown provenance, or missing
+  metadata. Record these as assumptions or blockers.
+- **Skill-quality-check ambiguity**: places where this skill did not say what to inspect or how to
+  decide. Only these count as unclear points for improving `skill-quality-check` itself.
+
+## Reference Checks
+
+Read [references/authoring-best-practices.md](references/authoring-best-practices.md) when a change
+touches structure, trigger design, bundled resources, domain separation, or scenario validation.

--- a/.agents/skills/skill-quality-check/agents/openai.yaml
+++ b/.agents/skills/skill-quality-check/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "Skill Quality Check"
+  short_description: "Quality-check Agent Skills."
+  default_prompt: >-
+    Quality-check this Agent Skill for trigger clarity, structure, progressive
+    disclosure, domain separation, and scenario validation readiness.

--- a/.agents/skills/skill-quality-check/references/authoring-best-practices.md
+++ b/.agents/skills/skill-quality-check/references/authoring-best-practices.md
@@ -1,0 +1,90 @@
+# Agent Skill Authoring Best Practices
+
+## Purpose
+
+Use this reference when a skill change needs more than the short checklist in `SKILL.md`. It
+summarizes stable guidance from agent skill documentation and adapts it into a repository-neutral
+review checklist.
+
+## Contents
+
+- Frontmatter and trigger quality
+- Scope and domain separation
+- Progressive disclosure
+- Workflow design
+- Resource selection
+- Validation and scenario testing
+
+## Frontmatter and Trigger Quality
+
+- Keep exactly one `name` and one `description` in `SKILL.md` frontmatter unless the local platform
+  explicitly requires more.
+- Use hyphen-case skill names with lowercase letters, digits, and hyphens.
+- Write `description` in third person, with the main use case and trigger terms early.
+- Include both positive triggers and practical boundaries. The body is loaded only after selection,
+  so do not rely on body-only "When to Use" text for discovery.
+- Check candidate user prompts against the description:
+  - Obvious in-scope prompts should select the skill.
+  - Adjacent but out-of-scope prompts should not select it unless paired with another skill.
+
+## Scope and Domain Separation
+
+- Keep one primary job per skill. A broad skill should coordinate smaller skills or point to
+  references instead of absorbing every detail.
+- Keep general workflow skills free of project-specific paths, product facts, business rules,
+  temporary status, or release-specific knowledge.
+- Put domain knowledge in one of these places:
+  - A dedicated domain skill when the knowledge changes how the agent should work.
+  - A directly linked reference file when the knowledge is detailed but optional.
+  - Repository docs when the information is primarily human-maintainer documentation.
+- Prefer splitting when a skill starts mixing reusable procedure with volatile facts, provider
+  matrices, schemas, or product-specific examples.
+
+## Progressive Disclosure
+
+- Treat `SKILL.md` as the overview and default workflow.
+- Move detailed variants, examples, schemas, and provider-specific instructions into directly
+  linked files under `references/`.
+- Keep references one level from `SKILL.md`; nested references are easy to miss during partial reads.
+- Add a table of contents to reference files longer than 100 lines.
+- Avoid duplicating the same rule in both `SKILL.md` and a reference. Keep the rule in the smallest
+  place that is reliably loaded when needed.
+- Remove placeholder `README.md`, quick references, changelogs, or process notes from skill folders
+  unless the skill explicitly uses them as output assets.
+
+## Workflow Design
+
+- Prefer `When to Use`, `Goals`, and `Workflow` for repository skills so agents can scan them
+  consistently.
+- Use ordered steps for operations where skipping validation changes the result.
+- Match instruction strictness to risk:
+  - Use flexible guidance when multiple approaches are valid.
+  - Use templates when output shape matters.
+  - Use exact commands or scripts when the operation is fragile or easy to perform inconsistently.
+- State required inputs, outputs, and completion criteria.
+- Keep examples short and realistic. Add examples only when they prevent a likely misread.
+- Avoid time-sensitive guidance unless it is framed as historical context or points to a maintained
+  source.
+
+## Resource Selection
+
+- Use `scripts/` for deterministic, repeated, or fragile operations. Test representative scripts
+  after editing them.
+- Use `references/` for detailed material that should be loaded only for relevant variants.
+- Use `assets/` for templates, images, fonts, starter files, or other output materials that do not
+  need to be read into context.
+- Keep `agents/openai.yaml` aligned with `SKILL.md` when present. Treat it as optional metadata, not
+  a substitute for a clear `description`.
+
+## Validation and Scenario Testing
+
+- Run any available structural validator for the skill folder.
+- Review the description/body consistency before scenario evaluation.
+- For each new or substantially revised skill, use scenario-based validation:
+  - Prepare two or three realistic scenarios before dispatching evaluators.
+  - Include at least one critical requirement per scenario.
+  - Use fresh evaluators for each iteration.
+  - Apply one theme of fixes per iteration.
+  - Maintain a failure-pattern ledger.
+  - Stop only at convergence, divergence, or an explicit resource cutoff.
+- Record what was tested, what was skipped, and why.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,5 @@
+# Agent Guidance
+
+- Use the Agent Skills in `.agents/skills/` when they match the task.
+- For repository changes, create task worktrees under `.agents/worktrees/`.
+- Keep changes focused, commit completed phases, and run the relevant project checks before opening or updating a pull request.


### PR DESCRIPTION
> [!WARNING]
> This pull request was created with assistance from LLMs.

## Summary

- Import Agent Skills from `aoirint/CruiserJumpPractice` at `3323f68f74a5d410386822f3648a6797f95e3494`.
- Keep all 12 source skills, including each `SKILL.md`, `agents/openai.yaml`, and referenced support files.
- Add minimal root `AGENTS.md` guidance for using the imported skills and task worktrees.
- Generalize source-project-specific examples so the skills fit this web repository.
- Remove source-template guidance that assumes `CONTRIBUTING.md` or a PR checklist/CLA section.

## Testing

### Automated checks

- `git diff --check`
- Verified every imported skill folder has both `SKILL.md` and `agents/openai.yaml`.
- Searched imported skills for source-project/game-specific wording and replaced the remaining examples.
- Searched the imported PR guidance for `CONTRIBUTING.md`, `CLA`, and source-template checklist assumptions.
- Searched imported skills and `AGENTS.md` for C# / .NET / NuGet-specific wording.

### AI-assisted inspections

Request: Import and adapt the Agent Skills using the source repository's own workflow guidance.
AI-assisted result: Used the imported `git-worktree-workflow`, `skill-quality-check`, `security-check`, `commit-message-quality-check`, and `pull-request-quality-check` guidance while preparing this branch and PR.
