### PR TITLE
docs: prepare v0.6.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and uses the repository tags and merged pull requests as its source of truth.
 
 ## [Unreleased]
 
+## [v0.6.0] - 2026-05-16 UTC
+
 ### Added
 
 - Added repository-local Agent Skills and root agent guidance for future
@@ -32,11 +34,6 @@ and uses the repository tags and merged pull requests as its source of truth.
   [Node.gitignore template][node-gitignore-template] and kept
   project-specific ignores for generated work directories, agent worktrees,
   `.vercel/`, `next-env.d.ts`, and environment files ([#70]).
-
-### Notes
-
-- No release version or UTC release date has been selected for the changes
-  above, so they remain under [Unreleased].
 
 ## [v0.5.2] - 2026-01-10 UTC
 
@@ -190,7 +187,8 @@ and uses the repository tags and merged pull requests as its source of truth.
   `ua-parser-js`, and `luxon` during early maintenance ([#4], [#5], [#6],
   [#7], [#8], [#21]).
 
-[Unreleased]: https://github.com/aoirint/harmonica/compare/0.5.2...main
+[Unreleased]: https://github.com/aoirint/harmonica/compare/0.6.0...main
+[v0.6.0]: https://github.com/aoirint/harmonica/releases/tag/0.6.0
 [v0.5.2]: https://github.com/aoirint/harmonica/releases/tag/0.5.2
 [v0.5.1]: https://github.com/aoirint/harmonica/releases/tag/0.5.1
 [v0.5.0]: https://github.com/aoirint/harmonica/releases/tag/0.5.0


### PR DESCRIPTION
> [!WARNING]
> This pull request was created with assistance from LLMs.

## Summary

- Move the current `CHANGELOG.md` `Unreleased` entries into `v0.6.0 - 2026-05-16 UTC`.
- Reset the `Unreleased` comparison link to start from `0.6.0` and add the `v0.6.0` release link.
- Leave package metadata unchanged because `package.json` is private and remains at the repository's existing `0.0.0` placeholder.

## Related Issues

None

## Notes for reviewers

- Local and remote tag checks found no existing `0.6.0` or `v0.6.0` tag before this PR was opened.
- Publication, tag creation, and GitHub release creation were not performed.

### AI disclosure

Codex prepared the changelog update, checked release-readiness inputs available in the repository, ran verification, and drafted this pull request body.

## Testing

### Automated checks

- `pnpm lint` - passed
- `git diff --check` - passed

### AI-assisted inspections

Request: Check the changelog release-preparation diff for version/date/link consistency and missing PR link references.

AI-assisted result: The `v0.6.0` section uses `2026-05-16 UTC`, `Unreleased` now compares `0.6.0...main`, the new release link follows existing tag URL style, and referenced pull requests have link definitions.
